### PR TITLE
Making midje-utils available in library

### DIFF
--- a/src/com/borkdal/squirrel/midje_utils.clj
+++ b/src/com/borkdal/squirrel/midje_utils.clj
@@ -1,4 +1,4 @@
-(ns com.borkdal.squirrel.test-utils
+(ns com.borkdal.squirrel.midje-utils
   (:require [midje.sweet :refer :all]
             [com.borkdal.squirrel.definitions :as defs]))
 

--- a/test/com/borkdal/squirrel/postgresql/language_def_test.clj
+++ b/test/com/borkdal/squirrel/postgresql/language_def_test.clj
@@ -1,6 +1,6 @@
 (ns com.borkdal.squirrel.postgresql.language-def-test
   (:require [midje.sweet :refer :all]
-            [com.borkdal.squirrel.test-utils :refer [sql]]
+            [com.borkdal.squirrel.midje-utils :refer [sql]]
             [com.borkdal.squirrel.definitions :as defs]
             [com.borkdal.squirrel.postgresql.language-def :refer :all]))
 


### PR DESCRIPTION
Providing a Midje checker for SQL strings.

See test/com/borkdal/squirrel/postgresql/language_def_test.clj for
examples on use.